### PR TITLE
Add support for integer battery levels.

### DIFF
--- a/rtl_433_prometheus_test.go
+++ b/rtl_433_prometheus_test.go
@@ -47,6 +47,7 @@ func TestParsingToMetrics(t *testing.T) {
 	wantTemperature := `
 		# HELP rtl_433_temperature_celsius Temperature in Celsius
 		# TYPE rtl_433_temperature_celsius gauge
+ 		rtl_433_temperature_celsius{channel="1",id="77",location="",model="AmbientWeather-TX8300"} 16.5
 		rtl_433_temperature_celsius{channel="1",id="94",location="",model="Nexus-TH"} 22.6
 		rtl_433_temperature_celsius{channel="2",id="184",location="",model="Nexus-TH"} 21.7
 		rtl_433_temperature_celsius{channel="3",id="55",location="",model="Ecowitt-WH53"} 18
@@ -60,6 +61,7 @@ func TestParsingToMetrics(t *testing.T) {
 	wantHumidity := `
 		# HELP rtl_433_humidity Relative Humidity (0-1.0)
 		# TYPE rtl_433_humidity gauge
+		rtl_433_humidity{channel="1",id="77",location="",model="AmbientWeather-TX8300"} 0.66
 		rtl_433_humidity{channel="1",id="94",location="",model="Nexus-TH"} 0.53
 		rtl_433_humidity{channel="2",id="184",location="",model="Nexus-TH"} 0.55
 		rtl_433_humidity{channel="A",id="7997",location="",model="Acurite-Tower"} 0.91
@@ -71,6 +73,7 @@ func TestParsingToMetrics(t *testing.T) {
 	wantPacketsReceived := `
 		# HELP rtl_433_packets_received Packets (temperature messages) received.
 		# TYPE rtl_433_packets_received counter
+		rtl_433_packets_received{channel="1",id="77",location="",model="AmbientWeather-TX8300"} 1
 		rtl_433_packets_received{channel="1",id="94",location="",model="Nexus-TH"} 1
 		rtl_433_packets_received{channel="2",id="184",location="",model="Nexus-TH"} 1
 		rtl_433_packets_received{channel="3",id="55",location="",model="Ecowitt-WH53"} 1

--- a/test_input.txt
+++ b/test_input.txt
@@ -2,3 +2,4 @@
 {"time" : "2019-06-16 07:18:06", "model" : "Nexus-TH", "id" : 184, "channel" : 2, "battery_ok" : 1, "temperature_C" : 21.700, "humidity" : 55}
 {"time" : "2019-06-16 07:18:16", "model" : "Nexus-TH", "id" : 94, "channel" : 1, "battery_ok" : 1, "temperature_C" : 22.600, "humidity" : 53}
 {"time" : "2019-06-16 07:18:51", "model" : "Ecowitt-WH53", "id" : 55, "channel" : 3, "temperature_C" : 18.000}
+{"time" : "2020-08-28 23:55:58", "model" : "AmbientWeather-TX8300", "id" : 77, "channel" : 1, "battery" : 2, "temperature_C" : 16.500, "humidity" : 66, "mic" : "CHECKSUM"}


### PR DESCRIPTION
Example code from rtl_433 that outputs int "battery":
https://github.com/merbanan/rtl_433/blob/master/src/devices/ambientweather_tx8300.c#L112

NOTE: parent commit is PR #3 so I could have green tests. Please merge this first, so I can rebase my PR on top of it.